### PR TITLE
Tweak `$GPG_KEYFILE` condition check

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -26,7 +26,7 @@ fi
 git config --global user.email "${GIT_USER_EMAIL:-root@gitsrv.git}"
 git config --global user.name "${GIT_USER_NAME:-root}"
 
-if [[ ! -z "${GPG_KEYFILE}" ]]; then
+if [ -n "${GPG_KEYFILE}" ]; then
   # Import the key
   gpg --import "${GPG_KEYFILE}"
 


### PR DESCRIPTION
The `-z` option caused the `run.sh` script to error if the variable
was not set. This commit changes it to `-n` which returns `TRUE` if
the variable is non zero in length, which is what I was after from
the beginning.