### PR TITLE
ci: push container image to fluxcd repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - '*'
 jobs:
-  push-container:
+  build-push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -14,6 +14,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: stefanprodan/gitsrv
+          repository: fluxcd/gitsrv
           tag_with_ref: true
           tag_with_sha: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gitsrv
 
+[![build](https://github.com/fluxcd/gitsrv/workflows/ci/badge.svg)](https://github.com/fluxcd/gitsrv/actions)
+
 SSH only Git Server used to host a git repository initialized from a tar.gz URL.
 
 Kubernetes deployment example:
@@ -23,7 +25,7 @@ spec:
         name: gitsrv
     spec:
       containers:
-      - image: stefanprodan/gitsrv:0.1.2
+      - image: fluxcd/gitsrv:0.1.3
         name: git
         env:
         - name: REPO


### PR DESCRIPTION
- push image to Docker Hub for master and git tags builds

Fix: #12