### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - master
-    tags:
-      - '*'
+
 jobs:
   build-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - '*'
 
 jobs:
   kubernetes:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: engineerd/setup-kind@v0.3.0
+      - name: Push image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: fluxcd/gitsrv
+          tag_with_ref: true
+      - name: Run release in cluster
+        run: |
+          test/ssh-keygen.sh
+          kubectl apply -k deploy
+          kubectl rollout status deployment/gitsrv --timeout=1m
+      - name: Generate the SSH fingerprint
+        run: test/ssh-keyscan.sh
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload SSH fingerprint
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./known_hosts.txt
+          asset_name: known_hosts.txt
+          asset_content_type: text/plain

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME:=gitsrv
 DOCKER_REPOSITORY:=fluxcd
 DOCKER_IMAGE_NAME:=$(DOCKER_REPOSITORY)/$(NAME)
-VERSION:=latest
+VERSION:=$(shell grep 'newTag' deploy/kustomization.yaml | awk '{ print $$2 }' | tr -d '"')
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ build:
 
 .PHONY: release
 release:
-	git tag "v$(VERSION)"
-	git push origin "v$(VERSION)"
+	git tag "$(VERSION)"
+	git push origin "$(VERSION)"
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Clone the repo from another pod that has the same `ssh-key` secret mounted:
 ```bash
 git clone -b master ssh://git@gitsrv/~/cluster.git
 ```
+
+## Release
+
+To make a gitsrv release do:
+* create a branch `prepare-v1.0.0`
+* bump the version in `deploy/kustomization/yaml`
+* merge PR
+* pull master and run `VERSION=1.0.0 make release`
+* the release workflow will kick in and push the image to Docker Hub and upload the SSH fingerprint to the release assets

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - name: REPO
               value: "cluster.git"
             - name: TAR_URL
-              value: "https://github.com/fluxcd/flux-get-started/archive/a4bdf4bb92c35cf9e944788368510168ee0bedf4.tar.gz"
+              value: "https://github.com/fluxcd/flux-get-started/archive/master.tar.gz"
           ports:
             - containerPort: 22
               name: ssh

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - service.yaml
 images:
   - name: fluxcd/gitsrv
-    newTag: 1.0.0
+    newTag: v1.0.0

--- a/test/ssh-keyscan.sh
+++ b/test/ssh-keyscan.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 repo_root=$(git rev-parse --show-toplevel)
-gen_dir=$(mktemp -d)
 
 kubectl exec -it deployment/gitsrv ssh-keyscan gitsrv > known_hosts.txt
 grep -E gitsrv known_hosts.txt


### PR DESCRIPTION
- push the container image to Docker Hub
- run the container in Kubernetes Kind
- generate SSH fingerprint
- create GH release
- upload SSH fingerprint to GH release as known_hosts.txt

Fix: #19