### PR TITLE
engineerd/setup-kind action updated to 0.5.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: engineerd/setup-kind@v0.3.0
+      - uses: engineerd/setup-kind@v0.5.0
       - name: Build container
         run: test/build.sh
       - name: Generate SSH key
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: engineerd/setup-kind@v0.3.0
+      - uses: engineerd/setup-kind@v0.5.0
       - name: Build container
         run: test/build.sh
       - name: Generate SSH key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: engineerd/setup-kind@v0.3.0
+      - uses: engineerd/setup-kind@v0.5.0
       - name: Push image
         uses: docker/build-push-action@v1
         with:


### PR DESCRIPTION
The build currently fails due to [deprecations](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), fixed in [0.5.0](https://github.com/engineerd/setup-kind/releases/tag/v0.5.0).

Signed-off-by: Jan Akerman <janakerman@users.noreply.github.com>